### PR TITLE
Only use scoverage when in Test. This removes the dependency on the r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,9 @@ This is a Scala Marathon Client. The aim is to provide a 100% coverage of the Ma
 ### Dependencies
 
     libraryDependencies ++= Seq(
-      "uk.co.appministry" %% "scathon-models" % "0.2.1",
-      "uk.co.appministry" %% "scathon-client" % "0.2.1"
+      "uk.co.appministry" %% "scathon-models" % "0.2.2",
+      "uk.co.appministry" %% "scathon-client" % "0.2.2"
     )
-
-In `project/plugins.sbt`, add:
-
-    addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 ### Scala 2.12
 
@@ -113,13 +109,13 @@ The project is very helpful is one's goal is to write a Marathon based applicati
 To use the test server in one's unit tests:
 
     libraryDependencies ++= Seq(
-      "org.appministry" %% "scathon-test-server" % "0.1.2" % "test"
+      "uk.co.appministry" %% "scathon-testserver" % "0.2.2" % "test"
     )
 
 In the unit tests:
 
     import uk.co.appministry.scathon.apiClient._
-    import org.appministry.scathon.testServer._
+    import uk.co.appministry.scathon.testServer._
     
     val server = new TestMarathon
     server.start()

--- a/project/BuildDefaults.scala
+++ b/project/BuildDefaults.scala
@@ -1,7 +1,7 @@
 object BuildDefaults {
 
   def buildScalaVersion = sys.props.getOrElse("scala.version", "2.11.8")
-  def buildVersion = "0.2.1"
+  def buildVersion = "0.2.2"
   def buildOrganization = "uk.co.appministry"
 
 }

--- a/scathon-client/build.sbt
+++ b/scathon-client/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
-coverageEnabled := true
+coverageEnabled in Test := true
 
 crossScalaVersions := Seq("2.11.8", "2.12.1")
 

--- a/scathon-models/build.sbt
+++ b/scathon-models/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
-coverageEnabled := false
+coverageEnabled in Test := true
 
 crossScalaVersions := Seq("2.11.8", "2.12.1")
 

--- a/scathon-testServer/build.sbt
+++ b/scathon-testServer/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
-coverageEnabled := false
+coverageEnabled in Test := true
 
 crossScalaVersions := Seq("2.11.8", "2.12.1")
 


### PR DESCRIPTION
…untime.